### PR TITLE
Ne fonctionne pas avec Django 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 account/settings.py
 projet/settings.py
+db.sqlite3.account

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN    apk update     \
            libc-dev   \
            python     \
            python-dev \
-           py-pip
+           py-pip     \
+           sqlite
 
 RUN    pip install      \
-           "django<1.9" \
+           django
 
 RUN    mkdir /home/banquelette/
 

--- a/README.md
+++ b/README.md
@@ -4,41 +4,26 @@
 Banquelette est un outil pour gérer ces comptes.
 
 ## Lancement via Docker
-Attention cette partie n'est plus à jour. Couchdb n'est plus utilisé et a été 
-remplacé par une base sqlite
-
 Banquelette est packagée pour Docker. Vous pouvez directement télécharger une
 image Docker fonctionnelle ou construire vous-même votre image (si vous
 souhaitez être certain d'avoir les tous derniers commits, par exemple).
 
-Vous aurez également besoin d'une image Docker de CouchDB pour héberger la base
-de donnée ([celle de klaemo](https://hub.docker.com/r/klaemo/couchdb)
-fonctionne par exemple très bien).
-
-Deux variables d'environnement principales sont à définir au moment de lancer
+Une variables d'environnement principales peut être définie au moment de lancer
 l'image:
 
-- ***COUCHDB_HOST*** contient l'adresse de la base de donnée (au format
-  hostname:port). Par défaut, elle vaut *db:5984*
-- ***SECRET_KEY*** est la clef secrète Django. Elle vaut par défaut une valeur
-  arbitraire. **Il est _TRÈS_ important de la changer**
+- ***SECRET_KEY*** est la clef secrète Django. Si vous ne la définissez pas
+  elle sera générée aléatoirement.
 
 ### Image docker préconstruite
 
 L'image à télécharger sur le Docker Hub est
-[lertsenem/banquelette](https://hub.docker.com/r/lertsenem/banquelette). Je
-suppose que vous disposez déjà de l'image *klaemo/couchdb* pour héberger la
-base de donées CouchDB. Remplacez-la éventuellement par ce que vous voulez.
+[lertsenem/banquelette](https://hub.docker.com/r/lertsenem/banquelette).
 
 ```
 	docker pull lertsenem/banquelette
 
-	docker run --name couchdb_banquelette klaemo/couchdb
-
 	docker run \
 		--name banquelette \
-		--link couchdb_banquelette:couchdb \
-		-e "COUCHDB_HOST=couchdb:5984" \
 		-e "SECRET_KEY=12345678abcdef" \
 		lertsenem/banquelette
 ```
@@ -47,8 +32,7 @@ base de donées CouchDB. Remplacez-la éventuellement par ce que vous voulez.
 ### Construire votre image Docker
 
 Tous les fichiers nécessaires sont déjà présents dans le repo git, qu'il va
-vous falloir cloner. Encore une fois ici, j'utilise l'image docker CouchDB de
-klaemo. Remplacez-la par ce que vous souhaitez.
+vous falloir cloner.
 
 ```
 	git clone https://github.com/mellecrepe/banquelette.git
@@ -57,34 +41,25 @@ klaemo. Remplacez-la par ce que vous souhaitez.
 
 	docker build -t test/banquelette .
 
-	docker run --name couchdb_banquelette klaemo/couchdb
-
 	docker run \
 		--name banquelette \
-		--link couchdb_banquelette:couchdb \
-		-e "COUCHDB_HOST=couchdb:5984" \
 		-e "SECRET_KEY=12345678abcdef" \
 		test/banquelette
 ```
 
 ## Lancement manuel
 ### Installation 
-Paquets à installer : *python2.7*, *django1.8*, *sqlite*"
+Paquets à installer : *python2.7*, *django*, *sqlite*"
 Par exemple, sous debian/ubuntu :
 ```
 	apt-get install python-django sqlite
 ```
 
-Assurez-vous d'avoir la version 1.8 grâce à cette commande :
+NOTE: Banquelette a été testé avec django v1.9. Vous pouvez vérifier la
+version de django grâce à cette commande :
 ```
 	django-admin --version
 ```
-
-Si la version de django est inférieur à 1.8, upgradez via cette commande :
-```
-	pip install django --upgrade
-```
-
 
 ### Configuration
 #### Configuration du schema de la base de données

--- a/account/settings.py.template
+++ b/account/settings.py.template
@@ -1,4 +1,4 @@
-#-*- coding: utf-9 -*-
+#-*- coding: utf-8 -*-
 # Fichiers de variables
 ###
 


### PR DESCRIPTION
Lorsqu'on essaie de lancer l'appli avec Django 1.9 (sorti en décembre), la
commande échoue avec l'exception suivante :

> /home/banquelette$ ./manage.py runserver
> [...]
> django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.

Aucun problème dès qu'on repasse à Django < 1.9.