### PR TITLE
Supression des warnings Django 1.10

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -3,16 +3,17 @@ from django.views.generic import ListView
 from account.models import Account
 from django.views.generic import RedirectView
 from django.core.urlresolvers import reverse_lazy
+from . import views
 
-urlpatterns = patterns('account.views',
-    url(r'^accueil$', 'home'),
-    url(r'^release$', 'release'),
-    url(r'^add$', 'db_add'),
-    url(r'^update$', 'db_update'),
-    url(r'^(?P<year>\d{4})/(?P<month>\d{2})$', 'month_view'),
-    url(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<category>\w+)$', 'month_view'),
-    url(r'^modify/(?P<year>\d{4})/(?P<month>\d{2})$', 'db_modify'),
-    url(r'^modify/nocheck$', 'db_modify'),
-    url(r'^modify/bymonth$', 'month_choice'),
+urlpatterns = [
+    url(r'^accueil$', views.home),
+    url(r'^release$', views.release),
+    url(r'^add$', views.db_add),
+    url(r'^update$', views.db_update),
+    url(r'^(?P<year>\d{4})/(?P<month>\d{2})$', views.month_view),
+    url(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<category>\w+)$', views.month_view),
+    url(r'^modify/(?P<year>\d{4})/(?P<month>\d{2})$', views.db_modify),
+    url(r'^modify/nocheck$', views.db_modify),
+    url(r'^modify/bymonth$', views.month_choice),
     url(r'^$', RedirectView.as_view(url='accueil'), name='redirect_home'),
-)
+]

--- a/projet/settings.py.template
+++ b/projet/settings.py.template
@@ -22,8 +22,6 @@ SECRET_KEY =
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False 
 
-TEMPLATE_DEBUG = False
-
 ALLOWED_HOSTS = ['localhost']
 
 
@@ -88,8 +86,19 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "static"),
 )
 
-#TEMPLATE_DIRS = ('/templates/')
-
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, "templates"),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [ os.path.join(BASE_DIR, "templates") ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': False,
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/projet/urls.py
+++ b/projet/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'', include('account.urls')),
-)
+]


### PR DESCRIPTION
En prévision de l'arrivée de Django v1.10, plusieurs fonctionnalités ont été dépréciées ce qui génère de nombreux warnings inutiles au démarrage du serveur Banquelette.